### PR TITLE
Fix natspec documentation typo

### DIFF
--- a/contracts/BatchDeposit.sol
+++ b/contracts/BatchDeposit.sol
@@ -57,7 +57,7 @@ contract BatchDeposit {
     ///         Will create a deposit transaction per index of the arrays submitted.
     ///
     /// @param pubkeys - An array of BLS12-381 public keys.
-    /// @param withdrawal_credentials - An array of public keys for withdrawals.
+    /// @param withdrawal_credentials - An array of commitment to public key for withdrawals.
     /// @param signatures - An array of BLS12-381 signatures.
     /// @param deposit_data_roots - An array of the SHA-256 hash of the SSZ-encoded DepositData object.
     function batchDeposit(


### PR DESCRIPTION
It read « public key » where the complete type is a « Commitment to a public key » as per https://github.com/ethereum/eth2.0-specs/blob/5da7674d2d386e1f42802db1c91d21183f1954a7/solidity_deposit_contract/deposit_contract.sol#L29